### PR TITLE
Explicitly added Maven central for plugin resolver

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,9 @@
 // repository for Typesafe plugins
 resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
 
+// explicitly add Maven Central in order to resolve workbench plugin below
+resolvers += "Maven central" at "https://repo1.maven.org/maven2/"
+
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.7.1")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.3")


### PR DESCRIPTION
When I checked out your awesome project it failed to resolve the workbench plugin.  Adding Maven central explicitly fixed it.  No idea why it would fail.  Is it failing for anybody else?
