### PR TITLE
server authentication/authorization support

### DIFF
--- a/doc/SUMMARY.md
+++ b/doc/SUMMARY.md
@@ -11,6 +11,7 @@
         - [Todo module and data flow](todo-module-and-data-flow.md)
         - [Autowire and BooPickle](autowire-and-boopickle.md)
     - [Server side](server-side.md)
+        - [Authentication](server-side-authentication.md)
 - [Testing](testing.md)
 - [Debugging](debugging.md)
 - [Logging](logging.md)

--- a/doc/server-side-authentication.md
+++ b/doc/server-side-authentication.md
@@ -1,0 +1,40 @@
+# Server side authentication
+
+A sample implementation of authentication and authorization is provided here as an example to get you started.  
+The BasicAuthController has an `auth` function that takes an email/password in basic auth form.
+It returns the role name as a string in response body and an authorization token in the response headers. 
+Save the token in the client to authenticate/authorize future requests.  Delete the token to logout.
+
+```scala
+trait BasicAuthController extends Controller with AuthElement with AuthConfigImpl {
+
+  def auth = StackAction(AuthorityKey -> NormalUser) { implicit request =>
+    Ok(loggedIn.role.toString)
+  }
+
+  def normal = StackAction(AuthorityKey -> NormalUser) { implicit request =>
+    Ok("loggedIn access")
+  }
+
+  def admin = StackAction(AuthorityKey -> Administrator) { implicit request =>
+    Ok("administrator access")
+  }
+
+}
+```
+
+To test authentication manually:
+```
+curl -i -v -u "alice@example.com:secret" http://localhost:9000/basic/auth
+```
+Note Authorization header in verbose output
+
+To test authorization of assigned roles manually:
+```
+curl -i -H "Authorization: Basic <token>" http://localhost:9000/basic/normal
+curl -i -H "Authorization: Basic <token>" http://localhost:9000/basic/admin
+```
+
+
+See [play2-auth](https://github.com/t2v/play2-auth) for more auth examples and options.
+For more advanced needs, consider the [silhouette](http://silhouette.mohiva.com/docs) authentication library.

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -54,7 +54,8 @@ object Settings {
   val jvmDependencies = Def.setting(Seq(
     "com.vmunier" %% "play-scalajs-scripts" % versions.playScripts,
     "org.webjars" % "font-awesome" % "4.3.0-1" % Provided,
-    "org.webjars" % "bootstrap" % versions.bootstrap % Provided
+    "org.webjars" % "bootstrap" % versions.bootstrap % Provided,
+    "jp.t2v" %% "play2-auth" % "0.14.1"
   ))
 
   /** Dependencies only used by the JS project (note the use of %%% instead of %%) */

--- a/server/src/main/resources/routes
+++ b/server/src/main/resources/routes
@@ -14,3 +14,8 @@ POST    /api/*path                        controllers.Application.autowireApi(pa
 
 # Logging
 POST /logging                             controllers.Application.logging
+
+# HTTP Basic Auth
+GET         /basic/auth                controllers.BasicAuthController.auth
+GET         /basic/normal              controllers.BasicAuthController.normal
+GET         /basic/admin               controllers.BasicAuthController.admin

--- a/server/src/main/scala/controllers/BasicAuthController.scala
+++ b/server/src/main/scala/controllers/BasicAuthController.scala
@@ -1,0 +1,120 @@
+package controllers
+
+import java.nio.charset.Charset
+
+import jp.t2v.lab.play2.auth._
+import models.Role.{Administrator, NormalUser}
+import models.{Account, Role}
+import org.apache.commons.codec.binary.Base64
+import play.api.mvc.Results._
+import play.api.mvc.{Controller, RequestHeader, Result}
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.reflect.{ClassTag, classTag}
+
+
+/**
+  * This controller provides an example for authenticating using email/password
+  * and getting back a token.  To test authentication manually:
+  * curl -i -v -u "alice@example.com:secret" http://localhost:9000/basic/auth
+  * Note Authorization header in verbose output
+  *
+  * Authorization
+  * curl -i -H "Authorization: Basic <token>" http://localhost:9000/basic/normal
+  * curl -i -H "Authorization: Basic <token>" http://localhost:9000/basic/admin
+  *
+  * Sample data initialized in Global.scala
+  * See play2-auth (https://github.com/t2v/play2-auth) for more auth examples.
+  */
+trait BasicAuthController extends Controller with AuthElement with AuthConfigImpl {
+
+  def auth = StackAction(AuthorityKey -> NormalUser) { implicit request =>
+    Ok(loggedIn.role.toString)
+  }
+
+  def normal = StackAction(AuthorityKey -> NormalUser) { implicit request =>
+    Ok("loggedIn access")
+  }
+
+  def admin = StackAction(AuthorityKey -> Administrator) { implicit request =>
+    Ok("administrator access")
+  }
+
+}
+
+object BasicAuthController extends BasicAuthController
+
+
+/**
+  * This is a simple implementation of play2-auth config framework taken from their basic sample.
+  * See play2-auth (https://github.com/t2v/play2-auth) for more information.
+  */
+trait AuthConfigImpl extends AuthConfig {
+
+  type Id = Account
+  type User = Account
+  type Authority = Role
+
+  val idTag: ClassTag[Id] = classTag[Id]
+  val sessionTimeoutInSeconds = 3600
+
+  def resolveUser(id: Id)(implicit ctx: ExecutionContext) = Future.successful(Some(id))
+
+  def authorize(user: User, authority: Authority)(implicit ctx: ExecutionContext) = Future.successful((user.role, authority) match {
+    case (Administrator, _) => true
+    case (NormalUser, NormalUser) => true
+    case _ => false
+  })
+
+  def loginSucceeded(request: RequestHeader)(implicit ctx: ExecutionContext) = throw new AssertionError("don't use application Login")
+
+  def logoutSucceeded(request: RequestHeader)(implicit ctx: ExecutionContext) = throw new AssertionError("don't use application Logout")
+
+  def authenticationFailed(request: RequestHeader)(implicit ctx: ExecutionContext) = Future.successful {
+    Unauthorized.withHeaders("WWW-Authenticate" -> """Basic realm="SECRET AREA"""")
+  }
+
+  def authorizationFailed(request: RequestHeader, user: User, authority: Option[Authority])(implicit ctx: ExecutionContext) = Future.successful(Forbidden("no permission"))
+
+  override lazy val idContainer = new BasicAuthIdContainer
+
+  override lazy val tokenAccessor = new BasicAuthTokenAccessor
+
+}
+
+class BasicAuthTokenAccessor extends TokenAccessor {
+
+  override def delete(result: Result)(implicit request: RequestHeader): Result = result
+
+  override def put(token: AuthenticityToken)(result: Result)(implicit request: RequestHeader): Result = result
+
+  override def extract(request: RequestHeader): Option[AuthenticityToken] = {
+    val encoded = for {
+      h <- request.headers.get("Authorization")
+      if h.startsWith("Basic ")
+    } yield h.substring(6)
+    encoded.map(s => new String(Base64.decodeBase64(s), Charset.forName("UTF-8")))
+  }
+
+}
+
+class BasicAuthIdContainer extends AsyncIdContainer[Account] {
+  override def prolongTimeout(token: AuthenticityToken, timeoutInSeconds: Int)(implicit request: RequestHeader, context: ExecutionContext): Future[Unit] = {
+    Future.successful(())
+  }
+
+  override def get(token: AuthenticityToken)(implicit context: ExecutionContext): Future[Option[Account]] = Future {
+    val Pattern = "(.*?):(.*)".r
+    PartialFunction.condOpt(token) {
+      case Pattern(user, pass) => Account.authenticate(user, pass)
+    }.flatten
+  }
+
+  override def remove(token: AuthenticityToken)(implicit context: ExecutionContext): Future[Unit] = {
+    Future.successful(())
+  }
+
+  override def startNewSession(userId: Account, timeoutInSeconds: Int)(implicit request: RequestHeader, context: ExecutionContext): Future[AuthenticityToken] = {
+    throw new AssertionError("don't use")
+  }
+}

--- a/server/src/main/scala/models/Account.scala
+++ b/server/src/main/scala/models/Account.scala
@@ -1,0 +1,38 @@
+package models
+
+import models.Role.{Administrator, NormalUser}
+
+sealed trait Role
+
+object Role {
+
+  case object Administrator extends Role
+
+  case object NormalUser extends Role
+
+  def valueOf(value: String): Role = value match {
+    case "Administrator" => Administrator
+    case "NormalUser" => NormalUser
+    case _ => throw new IllegalArgumentException()
+  }
+
+}
+
+case class Account(id: Int, email: String, password: String, name: String, role: Role)
+
+/**
+  * Sample model providing email/password and role to demonstrate authentication/authorization.
+  * See play2-auth samples (https://github.com/t2v/play2-auth) for more options.
+  */
+object Account {
+
+  val accounts = Seq(
+    Account(1, "alice@example.com", "secret", "Alice", Administrator),
+    Account(2, "bob@example.com", "secret", "Bob", NormalUser),
+    Account(3, "chris@example.com", "secret", "Chris", NormalUser))
+
+  def authenticate(email: String, password: String): Option[Account] = {
+    accounts.find(a => a.email == email && a.password == password)
+  }
+
+}


### PR DESCRIPTION
I feel like most people would really benefit from an example of how to work in proper client authentication/authorization into this spa tutorial.  This pull request is an attempt to add the prerequisite server side support to get that party started and help people that need client/server auth hit the ground running.  controllers.auth.BasicAuth provides an auth function that takes email/password and returns a token that can be used for future requests.  I assume basic auth and tokens that is what the spa client would want. 
