### PR TITLE
Use sbt-web-scalajs v1.0.1 and scalajs-scripts v1.0.0.

### DIFF
--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -37,7 +37,7 @@ object Settings {
     val bootstrap = "3.3.6"
     val chartjs = "2.1.3"
 
-    val playScripts = "0.5.0"
+    val scalajsScripts = "1.0.0"
   }
 
   /**
@@ -51,7 +51,7 @@ object Settings {
 
   /** Dependencies only used by the JVM project */
   val jvmDependencies = Def.setting(Seq(
-    "com.vmunier" %% "play-scalajs-scripts" % versions.playScripts,
+    "com.vmunier" %% "scalajs-scripts" % versions.scalajsScripts,
     "org.webjars" % "font-awesome" % "4.3.0-1" % Provided,
     "org.webjars" % "bootstrap" % versions.bootstrap % Provided,
     "com.lihaoyi" %% "utest" % versions.uTest % Test

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,7 +9,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.0.0")
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.3")
 
-addSbtPlugin("com.vmunier" % "sbt-play-scalajs" % "0.3.0")
+addSbtPlugin("com.vmunier" % "sbt-web-scalajs" % "1.0.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.0")
 

--- a/server/src/main/scala/controllers/Application.scala
+++ b/server/src/main/scala/controllers/Application.scala
@@ -4,7 +4,7 @@ import java.nio.ByteBuffer
 
 import boopickle.Default._
 import com.google.inject.Inject
-import play.api.{Configuration, Environment}
+import play.api.Configuration
 import play.api.mvc._
 import services.ApiService
 import spatutorial.shared.Api
@@ -16,7 +16,7 @@ object Router extends autowire.Server[ByteBuffer, Pickler, Pickler] {
   override def write[R: Pickler](r: R) = Pickle.intoBytes(r)
 }
 
-class Application @Inject() (implicit val config: Configuration, env: Environment) extends Controller {
+class Application @Inject() (implicit val config: Configuration) extends Controller {
   val apiService = new ApiService()
 
   def index = Action {

--- a/server/src/main/twirl/views/index.scala.html
+++ b/server/src/main/twirl/views/index.scala.html
@@ -1,4 +1,4 @@
-@(title: String)(implicit config: play.api.Configuration, env: play.api.Environment)
+@(title: String)(implicit config: play.api.Configuration)
 @import views.html.tags._
 
 <!DOCTYPE html>
@@ -14,6 +14,6 @@
     <body>
         <div id="root">
         </div>
-        @playscalajs.html.scripts(projectName = "client", fileName => _asset(fileName).toString)
+        @scalajs.html.scripts(projectName = "client", name => _asset(name).toString, name => getClass.getResource(s"/public/$name") != null)
     </body>
 </html>


### PR DESCRIPTION
Changes from `sbt-web-scalajs`:
- `build.sbt` uses the `scalaJSPipeline` task, which runs scalaJSDev in dev mode, runs scalaJSProd otherwise.
  The plugin is in dev mode when the user executes one of the `devCommands`, which are `run`, `compile` and `re-start`. `devCommands` can be extended/overridden to contain different dev commands.
  More info in the README.md: https://github.com/vmunier/sbt-web-scalajs/tree/e14dc902cecefdf418c77c336166fdee7ce8f0e7#settings-and-tasks
- The plugin watches files from the Scala.js projects and thus aggregating the client projects in `server` is not needed for continuous compilation anymore.
  `compile in Compile <<= (compile in Compile) dependsOn scalaJSPipeline` triggers scalaJSPipeline when using continuous compilation.
  If a task has to be run on all projects, e.g. `clean` or `test` on all projects, it's good practice to use the root project: `scalajs-spa-tutorial/clean`.

Changes from `scalajs-scripts`:
- Drop the Play dependency
- No more implicit `Environment` parameter, a `resourceExists` parameter is required from all the Twirl templates instead.

Let me know if you have any questions.
