### PR TITLE
fix: com.typesafe#jse_2.10 not found

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 // repository for Typesafe plugins
-resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
+resolvers += Resolver.typesafeRepo("releases")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.13")
 


### PR DESCRIPTION
Hello,

`sbt run` produces the following error here : 

`sbt.ResolveException: unresolved dependency: com.typesafe#jse_2.10;1.0.0: not found`

In case this is a reproductible error, it can be fixed the same way as https://github.com/typesafehub/activator-hello-slick/pull/28/files .