### PR TITLE
Update to scalajs-react 1.0.1 (and other dependencies)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,8 +34,8 @@ lazy val client: Project = (project in file("client"))
     // yes, we want to package JS dependencies
     skip in packageJSDependencies := false,
     // use Scala.js provided launcher code to start the client app
-    persistLauncher := true,
-    persistLauncher in Test := false,
+    scalaJSUseMainModuleInitializer := true,
+    scalaJSUseMainModuleInitializer in Test := false,
     // use uTest framework for tests
     testFrameworks += new TestFramework("utest.runner.Framework")
   )
@@ -55,7 +55,7 @@ lazy val server = (project in file("server"))
     libraryDependencies ++= Settings.jvmDependencies.value,
     commands += ReleaseCmd,
     // triggers scalaJSPipeline when using compile or continuous compilation
-    compile in Compile <<= (compile in Compile) dependsOn scalaJSPipeline,
+    compile in Compile := ((compile in Compile) dependsOn scalaJSPipeline).value,
     // connect to the client project
     scalaJSProjects := clients,
     pipelineStages in Assets := Seq(scalaJSPipeline),

--- a/client/src/main/scala/spatutorial/client/SPAMain.scala
+++ b/client/src/main/scala/spatutorial/client/SPAMain.scala
@@ -1,8 +1,7 @@
 package spatutorial.client
 
-import japgolly.scalajs.react.ReactDOM
 import japgolly.scalajs.react.extra.router._
-import japgolly.scalajs.react.vdom.prefix_<^._
+import japgolly.scalajs.react.vdom.html_<^._
 import org.scalajs.dom
 import spatutorial.client.components.GlobalStyles
 import spatutorial.client.logger._
@@ -10,11 +9,11 @@ import spatutorial.client.modules._
 import spatutorial.client.services.SPACircuit
 
 import scala.scalajs.js
-import scala.scalajs.js.annotation.JSExport
-import scalacss.Defaults._
+import scala.scalajs.js.annotation.{JSExport, JSExportTopLevel}
+import CssSettings._
 import scalacss.ScalaCssReact._
 
-@JSExport("SPAMain")
+@JSExportTopLevel("SPAMain")
 object SPAMain extends js.JSApp {
 
   // Define the locations (pages) used in this application
@@ -66,6 +65,6 @@ object SPAMain extends js.JSApp {
     // create the router
     val router = Router(BaseUrl.until_#, routerConfig)
     // tell React to render the router in the document body
-    ReactDOM.render(router(), dom.document.getElementById("root"))
+    router().renderIntoDOM(dom.document.getElementById("root"))
   }
 }

--- a/client/src/main/scala/spatutorial/client/components/Bootstrap.scala
+++ b/client/src/main/scala/spatutorial/client/components/Bootstrap.scala
@@ -1,13 +1,12 @@
 package spatutorial.client.components
 
 import japgolly.scalajs.react._
-import japgolly.scalajs.react.vdom.prefix_<^._
-import japgolly.univeq.UnivEq
+import japgolly.scalajs.react.vdom.html_<^._
 
 import scala.language.implicitConversions
 import scala.scalajs.js
 import scalacss.ScalaCssReact._
-import scalacss.Defaults._
+import spatutorial.client.CssSettings._
 
 /**
  * Common Bootstrap components for scalajs-react
@@ -34,12 +33,12 @@ object Bootstrap {
 
     case class Props(onClick: Callback, style: CommonStyle.Value = CommonStyle.default, addStyles: Seq[StyleA] = Seq())
 
-    val component = ReactComponentB[Props]("Button")
+    val component = ScalaComponent.builder[Props]("Button")
       .renderPC((_, p, c) =>
-        <.button(bss.buttonOpt(p.style), p.addStyles, ^.tpe := "button", ^.onClick --> p.onClick, c)
+        <.button(bss.buttonOpt(p.style), p.addStyles.toTagMod, ^.tpe := "button", ^.onClick --> p.onClick, c)
       ).build
 
-    def apply(props: Props, children: ReactNode*) = component(props, children: _*)
+    def apply(props: Props, children: VdomNode*) = component(props)(children: _*)
     def apply() = component
   }
 
@@ -47,7 +46,7 @@ object Bootstrap {
 
     case class Props(heading: String, style: CommonStyle.Value = CommonStyle.default)
 
-    val component = ReactComponentB[Props]("Panel")
+    val component = ScalaComponent.builder[Props]("Panel")
       .renderPC((_, p, c) =>
         <.div(bss.panelOpt(p.style),
           <.div(bss.panelHeading, p.heading),
@@ -55,21 +54,20 @@ object Bootstrap {
         )
       ).build
 
-    def apply(props: Props, children: ReactNode*) = component(props, children: _*)
+    def apply(props: Props, children: VdomNode*) = component(props)(children: _*)
     def apply() = component
   }
 
   object Modal {
 
     // header and footer are functions, so that they can get access to the the hide() function for their buttons
-    case class Props(header: Callback => ReactNode, footer: Callback => ReactNode, closed: Callback, backdrop: Boolean = true,
+    case class Props(header: Callback => VdomNode, footer: Callback => VdomNode, closed: Callback, backdrop: Boolean = true,
                      keyboard: Boolean = true)
 
     class Backend(t: BackendScope[Props, Unit]) {
-      def hide = Callback {
+      def hide =
         // instruct Bootstrap to hide the modal
-        jQuery(t.getDOMNode()).modal("hide")
-      }
+        t.getDOMNode.map(jQuery(_).modal("hide")).void
 
       // jQuery event handler to be fired when the modal has been hidden
       def hidden(e: JQueryEventObject): js.Any = {
@@ -91,18 +89,18 @@ object Bootstrap {
       }
     }
 
-    val component = ReactComponentB[Props]("Modal")
-      .renderBackend[Backend]
+    val component = ScalaComponent.builder[Props]("Modal")
+      .renderBackendWithChildren[Backend]
       .componentDidMount(scope => Callback {
         val p = scope.props
         // instruct Bootstrap to show the modal
-        jQuery(scope.getDOMNode()).modal(js.Dynamic.literal("backdrop" -> p.backdrop, "keyboard" -> p.keyboard, "show" -> true))
+        jQuery(scope.getDOMNode).modal(js.Dynamic.literal("backdrop" -> p.backdrop, "keyboard" -> p.keyboard, "show" -> true))
         // register event listener to be notified when the modal is closed
-        jQuery(scope.getDOMNode()).on("hidden.bs.modal", null, null, scope.backend.hidden _)
+        jQuery(scope.getDOMNode).on("hidden.bs.modal", null, null, scope.backend.hidden _)
       })
       .build
 
-    def apply(props: Props, children: ReactElement*) = component(props, children: _*)
+    def apply(props: Props, children: VdomElement*) = component(props)(children: _*)
     def apply() = component
   }
 

--- a/client/src/main/scala/spatutorial/client/components/BootstrapStyles.scala
+++ b/client/src/main/scala/spatutorial/client/components/BootstrapStyles.scala
@@ -3,7 +3,7 @@ package spatutorial.client.components
 import japgolly.univeq.UnivEq
 import spatutorial.client.components.Bootstrap.CommonStyle
 
-import scalacss.Defaults._
+import spatutorial.client.CssSettings._
 import scalacss.internal.mutable
 import spatutorial.client.components.Bootstrap.CommonStyle._
 

--- a/client/src/main/scala/spatutorial/client/components/Chart.scala
+++ b/client/src/main/scala/spatutorial/client/components/Chart.scala
@@ -1,12 +1,12 @@
 package spatutorial.client.components
 
-import japgolly.scalajs.react.vdom.prefix_<^._
-import japgolly.scalajs.react.{Callback, ReactComponentB}
+import japgolly.scalajs.react.vdom.html_<^._
+import japgolly.scalajs.react.{Callback, ScalaComponent}
 import org.scalajs.dom.raw.HTMLCanvasElement
 
 import scala.scalajs.js
 import scala.scalajs.js.JSConverters._
-import scala.scalajs.js.annotation.JSName
+import scala.scalajs.js.annotation.JSGlobal
 
 @js.native
 trait ChartDataset extends js.Object {
@@ -75,7 +75,7 @@ object ChartConfiguration {
 
 // define a class to access the Chart.js component
 @js.native
-@JSName("Chart")
+@JSGlobal("Chart")
 class JSChart(ctx: js.Dynamic, config: ChartConfiguration) extends js.Object
 
 object Chart {
@@ -89,14 +89,13 @@ object Chart {
 
   case class ChartProps(name: String, style: ChartStyle, data: ChartData, width: Int = 500, height: Int = 300)
 
-  val Chart = ReactComponentB[ChartProps]("Chart")
+  val Chart = ScalaComponent.builder[ChartProps]("Chart")
     .render_P(p =>
-      <.canvas("width".reactAttr := p.width, "height".reactAttr := p.height)
+      <.canvas(VdomAttr("width") := p.width, VdomAttr("height") := p.height)
     )
-    .domType[HTMLCanvasElement]
     .componentDidMount(scope => Callback {
       // access context of the canvas
-      val ctx = scope.getDOMNode().getContext("2d")
+      val ctx = scope.getDOMNode.asInstanceOf[HTMLCanvasElement].getContext("2d")
       // create the actual chart using the 3rd party component
       scope.props.style match {
         case LineChart => new JSChart(ctx, ChartConfiguration("line", scope.props.data))

--- a/client/src/main/scala/spatutorial/client/components/GlobalStyles.scala
+++ b/client/src/main/scala/spatutorial/client/components/GlobalStyles.scala
@@ -1,6 +1,6 @@
 package spatutorial.client.components
 
-import scalacss.Defaults._
+import spatutorial.client.CssSettings._
 
 object GlobalStyles extends StyleSheet.Inline {
   import dsl._

--- a/client/src/main/scala/spatutorial/client/components/Icon.scala
+++ b/client/src/main/scala/spatutorial/client/components/Icon.scala
@@ -1,13 +1,12 @@
 package spatutorial.client.components
 
-import japgolly.scalajs.react.ReactNode
-import japgolly.scalajs.react.vdom.prefix_<^._
+import japgolly.scalajs.react.vdom.html_<^._
 
 /**
  * Provides type-safe access to Font Awesome icons
  */
 object Icon {
-  type Icon = ReactNode
+  type Icon = VdomNode
   def apply(name: String): Icon = <.i(^.className := s"fa fa-$name")
 
   def adjust = apply("adjust")

--- a/client/src/main/scala/spatutorial/client/components/JQuery.scala
+++ b/client/src/main/scala/spatutorial/client/components/JQuery.scala
@@ -3,7 +3,7 @@ package spatutorial.client.components
 import org.scalajs.dom._
 
 import scala.scalajs.js
-import scala.scalajs.js.annotation.JSName
+import scala.scalajs.js.annotation.JSGlobal
 
 /**
   * Minimal facade for JQuery. Use https://github.com/scala-js/scala-js-jquery or
@@ -15,7 +15,7 @@ trait JQueryEventObject extends Event {
 }
 
 @js.native
-@JSName("jQuery")
+@JSGlobal("jQuery")
 object JQueryStatic extends js.Object {
   def apply(element: Element): JQuery = js.native
 }

--- a/client/src/main/scala/spatutorial/client/components/Motd.scala
+++ b/client/src/main/scala/spatutorial/client/components/Motd.scala
@@ -4,7 +4,7 @@ import diode.react.ReactPot._
 import diode.react._
 import diode.data.Pot
 import japgolly.scalajs.react._
-import japgolly.scalajs.react.vdom.prefix_<^._
+import japgolly.scalajs.react.vdom.html_<^._
 import spatutorial.client.components.Bootstrap._
 import spatutorial.client.services.UpdateMotd
 
@@ -14,7 +14,7 @@ import spatutorial.client.services.UpdateMotd
 object Motd {
 
   // create the React component for holding the Message of the Day
-  val Motd = ReactComponentB[ModelProxy[Pot[String]]]("Motd")
+  val Motd = ScalaComponent.builder[ModelProxy[Pot[String]]]("Motd")
     .render_P { proxy =>
       Panel(Panel.Props("Message of the day"),
         // render messages depending on the state of the Pot

--- a/client/src/main/scala/spatutorial/client/components/TodoList.scala
+++ b/client/src/main/scala/spatutorial/client/components/TodoList.scala
@@ -1,7 +1,7 @@
 package spatutorial.client.components
 
 import japgolly.scalajs.react._
-import japgolly.scalajs.react.vdom.prefix_<^._
+import japgolly.scalajs.react.vdom.html_<^._
 import spatutorial.client.components.Bootstrap.{CommonStyle, Button}
 import spatutorial.shared._
 import scalacss.ScalaCssReact._
@@ -17,7 +17,7 @@ object TodoList {
     deleteItem: TodoItem => Callback
   )
 
-  private val TodoList = ReactComponentB[TodoListProps]("TodoList")
+  private val TodoList = ScalaComponent.builder[TodoListProps]("TodoList")
     .render_P(p => {
       val style = bss.listGroup
       def renderItem(item: TodoItem) = {
@@ -35,7 +35,7 @@ object TodoList {
           Button(Button.Props(p.deleteItem(item), addStyles = Seq(bss.pullRight, bss.buttonXS)), "Delete")
         )
       }
-      <.ul(style.listGroup)(p.items map renderItem)
+      <.ul(style.listGroup)(p.items toTagMod renderItem)
     })
     .build
 

--- a/client/src/main/scala/spatutorial/client/logger/Log4JavaScript.scala
+++ b/client/src/main/scala/spatutorial/client/logger/Log4JavaScript.scala
@@ -1,7 +1,7 @@
 package spatutorial.client.logger
 
 import scala.scalajs.js
-import scala.scalajs.js.annotation.JSName
+import scala.scalajs.js.annotation.JSGlobal
 
 /**
  * Facade for functions in log4javascript that we need
@@ -49,7 +49,7 @@ private[logger] trait JSLogger extends js.Object {
 private[logger] trait Layout extends js.Object
 
 @js.native
-@JSName("log4javascript.JsonLayout")
+@JSGlobal("log4javascript.JsonLayout")
 private[logger] class JsonLayout extends Layout
 
 @js.native
@@ -59,15 +59,15 @@ private[logger] trait Appender extends js.Object {
 }
 
 @js.native
-@JSName("log4javascript.BrowserConsoleAppender")
+@JSGlobal("log4javascript.BrowserConsoleAppender")
 private[logger] class BrowserConsoleAppender extends Appender
 
 @js.native
-@JSName("log4javascript.PopUpAppender")
+@JSGlobal("log4javascript.PopUpAppender")
 private[logger] class PopUpAppender extends Appender
 
 @js.native
-@JSName("log4javascript.AjaxAppender")
+@JSGlobal("log4javascript.AjaxAppender")
 private[logger] class AjaxAppender(url:String) extends Appender {
   def addHeader(header:String, value:String):Unit = js.native
 }

--- a/client/src/main/scala/spatutorial/client/modules/Dashboard.scala
+++ b/client/src/main/scala/spatutorial/client/modules/Dashboard.scala
@@ -4,7 +4,7 @@ import diode.data.Pot
 import diode.react._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.extra.router.RouterCtl
-import japgolly.scalajs.react.vdom.prefix_<^._
+import japgolly.scalajs.react.vdom.html_<^._
 import spatutorial.client.SPAMain.{Loc, TodoLoc}
 import spatutorial.client.components._
 
@@ -28,9 +28,9 @@ object Dashboard {
   )
 
   // create the React component for Dashboard
-  private val component = ReactComponentB[Props]("Dashboard")
+  private val component = ScalaComponent.builder[Props]("Dashboard")
     // create and store the connect proxy in state for later use
-    .initialState_P(props => State(props.proxy.connect(m => m)))
+    .initialStateFromProps(props => State(props.proxy.connect(m => m)))
     .renderPS { (_, props, state) =>
       <.div(
         // header, MessageOfTheDay and chart components

--- a/client/src/main/scala/spatutorial/client/modules/MainMenu.scala
+++ b/client/src/main/scala/spatutorial/client/modules/MainMenu.scala
@@ -3,7 +3,7 @@ package spatutorial.client.modules
 import diode.react.ModelProxy
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.extra.router.RouterCtl
-import japgolly.scalajs.react.vdom.prefix_<^._
+import japgolly.scalajs.react.vdom.html_<^._
 import spatutorial.client.SPAMain.{DashboardLoc, Loc, TodoLoc}
 import spatutorial.client.components.Bootstrap.CommonStyle
 import spatutorial.client.components.Icon._
@@ -18,14 +18,14 @@ object MainMenu {
 
   case class Props(router: RouterCtl[Loc], currentLoc: Loc, proxy: ModelProxy[Option[Int]])
 
-  private case class MenuItem(idx: Int, label: (Props) => ReactNode, icon: Icon, location: Loc)
+  private case class MenuItem(idx: Int, label: (Props) => VdomNode, icon: Icon, location: Loc)
 
   // build the Todo menu item, showing the number of open todos
-  private def buildTodoMenu(props: Props): ReactElement = {
+  private def buildTodoMenu(props: Props): VdomElement = {
     val todoCount = props.proxy().getOrElse(0)
     <.span(
       <.span("Todo "),
-      todoCount > 0 ?= <.span(bss.labelOpt(CommonStyle.danger), bss.labelAsBadge, todoCount)
+      <.span(bss.labelOpt(CommonStyle.danger), bss.labelAsBadge, todoCount).when(todoCount > 0)
     )
   }
 
@@ -42,20 +42,19 @@ object MainMenu {
     def render(props: Props) = {
       <.ul(bss.navbar)(
         // build a list of menu items
-        for (item <- menuItems) yield {
-          <.li(^.key := item.idx, (props.currentLoc == item.location) ?= (^.className := "active"),
-            props.router.link(item.location)(item.icon, " ", item.label(props))
-          )
-        }
+        menuItems.toVdomArray(item =>
+          <.li(^.key := item.idx, (^.className := "active").when(props.currentLoc == item.location),
+          props.router.link(item.location)(item.icon, " ", item.label(props))
+        ))
       )
     }
   }
 
-  private val component = ReactComponentB[Props]("MainMenu")
+  private val component = ScalaComponent.builder[Props]("MainMenu")
     .renderBackend[Backend]
     .componentDidMount(scope => scope.backend.mounted(scope.props))
     .build
 
-  def apply(ctl: RouterCtl[Loc], currentLoc: Loc, proxy: ModelProxy[Option[Int]]): ReactElement =
+  def apply(ctl: RouterCtl[Loc], currentLoc: Loc, proxy: ModelProxy[Option[Int]]): VdomElement =
     component(Props(ctl, currentLoc, proxy))
 }

--- a/client/src/main/scala/spatutorial/client/modules/TODO.scala
+++ b/client/src/main/scala/spatutorial/client/modules/TODO.scala
@@ -4,7 +4,7 @@ import diode.react.ReactPot._
 import diode.react._
 import diode.data.Pot
 import japgolly.scalajs.react._
-import japgolly.scalajs.react.vdom.prefix_<^._
+import japgolly.scalajs.react.vdom.html_<^._
 import spatutorial.client.components.Bootstrap._
 import spatutorial.client.components._
 import spatutorial.client.logger._
@@ -50,11 +50,11 @@ object Todo {
         // if the dialog is open, add it to the panel
         if (s.showTodoForm) TodoForm(TodoForm.Props(s.selectedItem, todoEdited))
         else // otherwise add an empty placeholder
-          Seq.empty[ReactElement])
+          VdomArray.empty())
   }
 
   // create the React component for To Do management
-  val component = ReactComponentB[Props]("TODO")
+  val component = ScalaComponent.builder[Props]("TODO")
     .initialState(State()) // initial state from TodoStore
     .renderBackend[Backend]
     .componentDidMount(scope => scope.backend.mounted(scope.props))
@@ -82,13 +82,13 @@ object TodoForm {
       // call parent handler with the new item and whether form was OK or cancelled
       props.submitHandler(state.item, state.cancelled)
 
-    def updateDescription(e: ReactEventI) = {
+    def updateDescription(e: ReactEventFromInput) = {
       val text = e.target.value
       // update TodoItem content
       t.modState(s => s.copy(item = s.item.copy(content = text)))
     }
 
-    def updatePriority(e: ReactEventI) = {
+    def updatePriority(e: ReactEventFromInput) = {
       // update TodoItem priority
       val newPri = e.currentTarget.value match {
         case p if p == TodoHigh.toString => TodoHigh
@@ -125,8 +125,8 @@ object TodoForm {
     }
   }
 
-  val component = ReactComponentB[Props]("TodoForm")
-    .initialState_P(p => State(p.item.getOrElse(TodoItem("", 0, "", TodoNormal, completed = false))))
+  val component = ScalaComponent.builder[Props]("TodoForm")
+    .initialStateFromProps(p => State(p.item.getOrElse(TodoItem("", 0, "", TodoNormal, completed = false))))
     .renderBackend[Backend]
     .build
 

--- a/client/src/main/scala/spatutorial/client/package.scala
+++ b/client/src/main/scala/spatutorial/client/package.scala
@@ -1,0 +1,7 @@
+package spatutorial
+
+package object client {
+
+  val CssSettings = scalacss.devOrProdDefaults
+
+}

--- a/doc/en/css-in-scala.md
+++ b/doc/en/css-in-scala.md
@@ -120,7 +120,7 @@ def renderItem(item: TodoItem) = {
     Button(Button.Props(() => P.deleteItem(item), addStyles = Seq(bss.pullRight, bss.buttonXS)), "Delete")
   )
 }
-<.ul(style.listGroup)(P.items map renderItem)
+<.ul(style.listGroup)(P.items toTagMod renderItem)
 ```
 
 As the Bootstrap class names are "hidden" behind Scala methods, you have full IDE code completion support and there is no chance of mistyping a class name

--- a/doc/en/dashboard.md
+++ b/doc/en/dashboard.md
@@ -7,9 +7,9 @@ fake data for the Chart component, to keep things simple.
 
 ```scala
 // create the React component for Dashboard
-private val component = ReactComponentB[Props]("Dashboard")
+private val component = ScalaComponent.builder[Props]("Dashboard")
   // create and store the connect proxy in state for later use
-  .initialState_P(props => State(props.proxy.connect(m => m)))
+  .initialStateFromProps(props => State(props.proxy.connect(m => m)))
   .renderPS { (_, props, state) =>
     <.div(
       // header, MessageOfTheDay and chart components
@@ -30,7 +30,7 @@ component that shows a *Message of the day* from the server in a panel. The `Mot
 `ModelProxy`).
 
 ```scala
-val Motd = ReactComponentB[ModelProxy[Pot[String]]]("Motd")
+val Motd = ScalaComponent.builder[ModelProxy[Pot[String]]]("Motd")
   .render_P { proxy =>
     Panel(Panel.Props("Message of the day"),
       // render messages depending on the state of the Pot

--- a/doc/en/main-menu.md
+++ b/doc/en/main-menu.md
@@ -7,14 +7,14 @@ a dynamic system, but static is just fine here.
 ```scala
 case class Props(ctl: RouterCtl[Loc], currentLoc: Loc, proxy: ModelProxy[Option[Int]])
 
-case class MenuItem(idx: Int, label: (Props) => ReactNode, icon: Icon, location: Loc)
+case class MenuItem(idx: Int, label: (Props) => VdomNode, icon: Icon, location: Loc)
 
 // build the Todo menu item, showing the number of open todos
-private def buildTodoMenu(props: Props): ReactNode = {
+private def buildTodoMenu(props: Props): VdomElement = {
   val todoCount = props.proxy().getOrElse(0)
   Seq(
     <.span("Todo "),
-    todoCount > 0 ?= <.span(bss.labelOpt(CommonStyle.danger), bss.labelAsBadge, todoCount)
+    <.span(bss.labelOpt(CommonStyle.danger), bss.labelAsBadge, todoCount).when(todoCount > 0)
   )
 }
 
@@ -40,7 +40,7 @@ private class Backend(t: BackendScope[Props, _]) {
     <.ul(bss.navbar)(
       // build a list of menu items
       for (item <- menuItems) yield {
-        <.li(^.key := item.idx, (props.currentLoc == item.location) ?= (^.className := "active"),
+        <.li(^.key := item.idx, (^.className := "active").when(props.currentLoc == item.location),
           props.router.link(item.location)(item.icon, " ", item.label(props))
         )
       }
@@ -48,8 +48,7 @@ private class Backend(t: BackendScope[Props, _]) {
   }
 }
 
-private val component = ReactComponentB[Props]("MainMenu")
-  .stateless
+private val component = ScalaComponent.builder[Props]("MainMenu")
   .renderBackend[Backend]
   .componentDidMount(scope => scope.backend.mounted(scope.props))
   .build

--- a/doc/en/routing.md
+++ b/doc/en/routing.md
@@ -34,7 +34,7 @@ The router provides the base HTML code (layout) and integrates a `MainMenu` comp
 uses Bootstrap CSS to provide a nice looking layout, but you can use whatever CSS framework you wish just by changing the CSS class definitions.
 
 ```scala
-import japgolly.scalajs.react.vdom.prefix_<^._
+import japgolly.scalajs.react.vdom.html_<^._
 val todoCountWrapper = SPACircuit.connect(_.todos.map(_.items.count(!_.completed)).toOption)
 def layout(c: RouterCtl[Loc], r: Resolution[Loc]) = {
   <.div(
@@ -55,7 +55,7 @@ def layout(c: RouterCtl[Loc], r: Resolution[Loc]) = {
 ```
 
 See how the code looks just like HTML, except it's type safe and the IDE provides auto-completion! If you insist on having even closer resemblance to HTML,
-you can replace the `prefix_<^` with `all` giving you simple `div` and `className` tag names. Be warned, however, that this may lead to nasty surprises
+you can replace the `html_<^` with `all` giving you simple `div` and `className` tag names. Be warned, however, that this may lead to nasty surprises
 down the road because the HTML namespace contains a lot of short, common tag names like `a` and `id`. The little extra effort from `<.` and `^.` pays
 off in the long run.
 

--- a/doc/en/sbt-build-definition.md
+++ b/doc/en/sbt-build-definition.md
@@ -58,8 +58,8 @@ lazy val client: Project = (project in file("client"))
     // yes, we want to package JS dependencies
     skip in packageJSDependencies := false,
     // use Scala.js provided launcher code to start the client app
-    persistLauncher := true,
-    persistLauncher in Test := false,
+    scalaJSUseMainModuleInitializer := true,
+    scalaJSUseMainModuleInitializer in Test := false,
     // must specify source maps location because we use pure CrossProject
     sourceMapsDirectories += sharedJS.base / "..",
     // use uTest framework for tests
@@ -92,8 +92,8 @@ Make sure you have installed [PhantomJS](http://phantomjs.org/) before running t
 
 ```scala
     // use Scala.js provided launcher code to start the client app
-    persistLauncher := true,
-    persistLauncher in Test := false,
+    scalaJSUseMainModuleInitializer := true,
+    scalaJSUseMainModuleInitializer in Test := false,
 ```
 This setting informs Scala.js plugin to generate a special `launcher.js` file, which is loaded last and invokes your `main` method. Using a launcher keeps
 your HTML template clean, as you don't need to specify the `main` function there.

--- a/doc/en/the-client.md
+++ b/doc/en/the-client.md
@@ -37,7 +37,7 @@ object SPAMain extends JSApp {
     // create the router
     val router = Router(BaseUrl.until_#, routerConfig)
     // tell React to render the router in the document body
-    React.render(router(), dom.document.getElementById("root"))
+    router().renderIntoDOM(dom.document.getElementById("root"))
   }
 }
 ```

--- a/doc/en/todo-module-and-data-flow.md
+++ b/doc/en/todo-module-and-data-flow.md
@@ -60,7 +60,7 @@ Todos.
 val todoCount = props.proxy().getOrElse(0)
 Seq(
   <.span("Todo "),
-  todoCount > 0 ?= <.span(bss.labelOpt(CommonStyle.danger), bss.labelAsBadge, todoCount)
+  <.span(bss.labelOpt(CommonStyle.danger), bss.labelAsBadge, todoCount).when(todoCount > 0)
 )
 ```
 
@@ -100,7 +100,7 @@ The `ModelProxy` wraps the extracted model and provides access to the dispatcher
 Within `Dashboard` we further connect the `Motd` component to the model using the `connect` method of the `ModelProxy`.
 
 ```scala
-.initialState_P(props => State(props.proxy.connect(m => m)))
+.initialStateFromProps(props => State(props.proxy.connect(m => m)))
 ...
 state.motdWrapper(Motd(_))
 ```
@@ -167,8 +167,8 @@ case class State(item: TodoItem, cancelled: Boolean = true)
 
 Building the component looks a bit complicated, so let's walk through it.
 ```scala
-val component = ReactComponentB[Props]("TodoForm")
-  .initialState_P(p => State(p.item.getOrElse(TodoItem("", 0, "", TodoNormal, false))))
+val component = ScalaComponent.builder[Props]("TodoForm")
+  .initialStateFromProps(p => State(p.item.getOrElse(TodoItem("", 0, "", TodoNormal, false))))
   .renderBackend[Backend]
   .build
   

--- a/doc/jp/css-in-scala.md
+++ b/doc/jp/css-in-scala.md
@@ -118,7 +118,7 @@ def renderItem(item: TodoItem) = {
     Button(Button.Props(() => P.deleteItem(item), addStyles = Seq(bss.pullRight, bss.buttonXS)), "Delete")
   )
 }
-<.ul(style.listGroup)(P.items map renderItem)
+<.ul(style.listGroup)(P.items toTagMod renderItem)
 ```
 
 As the Bootstrap class names are "hidden" behind Scala methods, you have full IDE code completion support and there is no chance of mistyping a class name

--- a/doc/jp/dashboard.md
+++ b/doc/jp/dashboard.md
@@ -6,7 +6,7 @@
 
 ```scala
 // ダッシュボード用Reactコンポーネントの作成
-private val component = ReactComponentB[Props]("Dashboard")
+private val component = ScalaComponent.builder[Props]("Dashboard")
   .render_P { case Props(router, proxy) =>
     <.div(
       // header、MessageOfTheDay、chartコンポーネント
@@ -25,7 +25,7 @@ private val component = ReactComponentB[Props]("Dashboard")
 [Motdコンポーネント](https://github.com/ochrons/scalajs-spa-tutorial/tree/master/client/src/main/scala/spatutorial/client/components/Motd.scala)は*今日のメッセージ*をサーバーから取得し、パネル上に表示するシンプルなReactコンポーネントです。
 `Motd`はプロパティでメッセージを与えられます（`Pot`と`ModelProxy`）。
 ```scala
-val Motd = ReactComponentB[ModelProxy[Pot[String]]]("Motd")
+val Motd = ScalaComponent.builder[ModelProxy[Pot[String]]]("Motd")
   .render_P { proxy =>
     Panel(Panel.Props("Message of the day"),
       // Potの状態に応じてメッセージを表示する

--- a/doc/jp/integrating-javascript-components.md
+++ b/doc/jp/integrating-javascript-components.md
@@ -28,12 +28,12 @@ object Button {
 
   case class Props(onClick: Callback, style: CommonStyle.Value = CommonStyle.default, addStyles: Seq[StyleA] = Seq())
 
-  val component = ReactComponentB[Props]("Button")
+  val component = ScalaComponent.builder[Props]("Button")
     .renderPC((_, props, children) =>
-      <.button(bss.buttonOpt(props.style), props.addStyles, ^.tpe := "button", ^.onClick --> props.onClick, children)
+      <.button(bss.buttonOpt(props.style), props.addStyles.toTagMod, ^.tpe := "button", ^.onClick --> props.onClick, children)
     ).build
 
-  def apply(props: Props, children: ReactNode*) = component(props, children: _*)
+  def apply(props: Props, children: ReactNode*) = component(props)(children: _*)
   def apply() = component
 }
 ```
@@ -48,7 +48,7 @@ Defining a Bootstrap Panel is about as simple.
 object Panel {
   case class Props(heading: String, style: CommonStyle.Value = CommonStyle.default)
 
-  val component = ReactComponentB[Props]("Panel")
+  val component = ScalaComponent.builder[Props]("Panel")
     .renderPC((_, p, c) =>
       <.div(bss.panelOpt(p.style),
         <.div(bss.panelHeading, p.heading),
@@ -56,7 +56,7 @@ object Panel {
       )
     ).build
 
-  def apply(props: Props, children: ReactNode*) = component(props, children: _*)
+  def apply(props: Props, children: ReactNode*) = component(props)(children: _*)
   def apply() = component
 }
 ```
@@ -70,7 +70,7 @@ Custom fonts are a great way to generate scalable icons that look good on all di
 
 ```scala
 object Icon {
-  type Icon = ReactTag
+  type Icon = VdomNode
   def apply(name: String): Icon = <.i(^.className := s"fa fa-$name")
 
   def adjust = apply("adjust")
@@ -102,7 +102,7 @@ To do the same in Scala.js we define a simple *facade* as follows
 
 ```scala
 @js.native
-@JSName("Chart")
+@JSGlobal("Chart")
 class JSChart(ctx: js.Dynamic) extends js.Object {
   def Line(data: ChartData): js.Dynamic = js.native
   def Bar(data: ChartData): js.Dynamic = js.native
@@ -114,18 +114,17 @@ skipping the `options` parameter for charts to keep things simple.
 To actually instantiate the chart, we need access to the canvas element and with React this is a bit problematic since it builds a virtual-DOM and
 updates the real DOM behind the scene. Therefore the canvas element does not exist at the time of `render` function call. To work around this problem
 we need to build the chart in the `componentDidMount` function, which is called after the real DOM has been updated. This function is called with
-a `scope` parameter that gives us access to the actual DOM node through `getDOMNode()`. The chart is built by creating a new instance of `Chart`
+a `scope` parameter that gives us access to the actual DOM node through `getDOMNode`. The chart is built by creating a new instance of `Chart`
 and calling the appropriate chart function.
 
 ```scala
-val Chart = ReactComponentB[ChartProps]("Chart")
+val Chart = ScalaComponent.builder[ChartProps]("Chart")
   .render_P((P) => {
-    <.canvas(^.width := P.width, ^.height := P.height)
-  })    
-  .domType[HTMLCanvasElement]
+    <.canvas(VdomAttr("width") := p.width, VdomAttr("height") := p.height)
+  })
   .componentDidMount(scope => Callback {
     // access context of the canvas
-    val ctx = scope.getDOMNode().getContext("2d")
+    val ctx = scope.getDOMNode.asInstanceOf[HTMLCanvasElement].getContext("2d")
     // create the actual chart using the 3rd party component
     scope.props.style match {
       case LineChart => new JSChart(ctx).Line(scope.props.data)
@@ -208,7 +207,7 @@ jQuery works by "calling" it with a selector or an element. In this tutorial we 
 For example to attach an event listener to an element, you would call
 
 ```scala
-jQuery(scope.getDOMNode()).on("hidden.bs.modal", null, null, scope.backend.hidden _)
+jQuery(scope.getDOMNode).on("hidden.bs.modal", null, null, scope.backend.hidden _)
 ```
 
 jQuery has an extension mechanism where plugins can add new functions to the jQuery object. For example Bootstrap Modal adds a `modal` function. To define such
@@ -234,10 +233,9 @@ In the `Backend` of the `Modal` we define a `hide()` function to do just that.
 
 ```scala
 class Backend(t: BackendScope[Props, Unit]) {
-  def hide = Callback {
+  def hide =
     // instruct Bootstrap to hide the modal
-    jQuery(t.getDOMNode()).modal("hide")
-  }
+    t.getDOMNode.map(jQuery(_).modal("hide")).void
 ```
 
 However, because the dialog box itself contains controls that need to actually close the dialog, we need to expose this functionality to the parent
@@ -246,7 +244,7 @@ component via properties.
 ```scala
 // header and footer are functions, so that they can get access to the 
 // hide() function for their buttons
-case class Props(header: Callback => ReactNode, footer: Callback => ReactNode, 
+case class Props(header: Callback => VdomNode, footer: Callback => VdomNode,
                  closed: Callback, backdrop: Boolean = true,
                  keyboard: Boolean = true)
 ```
@@ -261,7 +259,7 @@ def hidden(e: JQueryEventObject): js.Any = {
 }
 ...
 // register event listener to be notified when the modal is closed
-jQuery(scope.getDOMNode()).on("hidden.bs.modal", null, null, scope.backend.hidden _)
+jQuery(scope.getDOMNode).on("hidden.bs.modal", null, null, scope.backend.hidden _)
 ```
 
 To show the dialog box after it has been created, we again call `modal()` via jQuery in `componentDidMount`.
@@ -269,6 +267,6 @@ To show the dialog box after it has been created, we again call `modal()` via jQ
 .componentDidMount(scope => Callback {
   val P = scope.props
   // instruct Bootstrap to show the modal
-  jQuery(scope.getDOMNode()).modal(js.Dynamic.literal("backdrop" -> P.backdrop, "keyboard" -> P.keyboard, "show" -> true))
+  jQuery(scope.getDOMNode).modal(js.Dynamic.literal("backdrop" -> P.backdrop, "keyboard" -> P.keyboard, "show" -> true))
 ```
 

--- a/doc/jp/main-menu.md
+++ b/doc/jp/main-menu.md
@@ -5,14 +5,14 @@
 ```scala
 case class Props(ctl: RouterCtl[Loc], currentLoc: Loc, proxy: ModelProxy[Option[Int]])
 
-case class MenuItem(idx: Int, label: (Props) => ReactNode, icon: Icon, location: Loc)
+case class MenuItem(idx: Int, label: (Props) => VdomNode, icon: Icon, location: Loc)
 
 // Todoメニュー項目を作成して、未完了のTodo数を表示します
-private def buildTodoMenu(props: Props): ReactNode = {
+private def buildTodoMenu(props: Props): VdomElement = {
   val todoCount = props.proxy().getOrElse(0)
   Seq(
     <.span("Todo "),
-    todoCount > 0 ?= <.span(bss.labelOpt(CommonStyle.danger), bss.labelAsBadge, todoCount)
+    <.span(bss.labelOpt(CommonStyle.danger), bss.labelAsBadge, todoCount).when(todoCount > 0)
   )
 }
 
@@ -38,7 +38,7 @@ private class Backend(t: BackendScope[Props, _]) {
     <.ul(bss.navbar)(
       // メニュー項目のリストを作成する
       for (item <- menuItems) yield {
-        <.li(^.key := item.idx, (props.currentLoc == item.location) ?= (^.className := "active"),
+        <.li(^.key := item.idx, (^.className := "active").when(props.currentLoc == item.location),
           props.router.link(item.location)(item.icon, " ", item.label(props))
         )
       }
@@ -46,8 +46,7 @@ private class Backend(t: BackendScope[Props, _]) {
   }
 }
 
-private val component = ReactComponentB[Props]("MainMenu")
-  .stateless
+private val component = ScalaComponent.builder[Props]("MainMenu")
   .renderBackend[Backend]
   .componentDidMount(scope => scope.backend.mounted(scope.props))
   .build

--- a/doc/jp/routing.md
+++ b/doc/jp/routing.md
@@ -24,7 +24,7 @@ val routerConfig = RouterConfigDsl[Loc].buildConfig { dsl =>
 ルータは、基本的なHTMLコード(layout)を提供して、アプリケーションのための`MainMenu`コンポーネントを統合します。このチュートリアルは、Bootstrap CSSを使用して見栄えの良いレイアウトを提供していますが、CSSクラスの定義を変更することで、あなたが使用したいCSSフレームワークは何でも使うことができます。
 
 ```scala
-import japgolly.scalajs.react.vdom.prefix_<^._
+import japgolly.scalajs.react.vdom.html_<^._
 def layout(c: RouterCtl[Loc], r: Resolution[Loc]) = {
   <.div(
     // here we use plain Bootstrap class names as these are specific to the top level layout defined here
@@ -43,4 +43,4 @@ def layout(c: RouterCtl[Loc], r: Resolution[Loc]) = {
 }
 ```
 
-型安全性、IDEが自動補完を提供するという点を除いて、コードがHTMLとどれだけ似ているか確認してください！HTMLともっと似ていると主張する場合、 `prefix_<^`を`all`に置き換えるだけの簡単`div`と`className`タグ名を与えることができます。ただし、HTMLの名前空間には`a`や`id`のような短い共通タグ名が多く含まれているので、不快な驚きとなるかもしれないので気をつけてください。`<.`と`^.`の少しの努力は、長期的に補償します。
+型安全性、IDEが自動補完を提供するという点を除いて、コードがHTMLとどれだけ似ているか確認してください！HTMLともっと似ていると主張する場合、 `html_<^`を`all`に置き換えるだけの簡単`div`と`className`タグ名を与えることができます。ただし、HTMLの名前空間には`a`や`id`のような短い共通タグ名が多く含まれているので、不快な驚きとなるかもしれないので気をつけてください。`<.`と`^.`の少しの努力は、長期的に補償します。

--- a/doc/jp/sbt-build-definition.md
+++ b/doc/jp/sbt-build-definition.md
@@ -59,8 +59,8 @@ lazy val client: Project = (project in file("client"))
     // yes, we want to package JS dependencies
     skip in packageJSDependencies := false,
     // use Scala.js provided launcher code to start the client app
-    persistLauncher := true,
-    persistLauncher in Test := false,
+    scalaJSUseMainModuleInitializer := true,
+    scalaJSUseMainModuleInitializer in Test := false,
     // must specify source maps location because we use pure CrossProject
     sourceMapsDirectories += sharedJS.base / "..",
     // use uTest framework for tests
@@ -93,8 +93,8 @@ Make sure you have installed [PhantomJS](http://phantomjs.org/) before running t
 
 ```scala
     // use Scala.js provided launcher code to start the client app
-    persistLauncher := true,
-    persistLauncher in Test := false,
+    scalaJSUseMainModuleInitializer := true,
+    scalaJSUseMainModuleInitializer in Test := false,
 ```
 This setting informs Scala.js plugin to generate a special `launcher.js` file, which is loaded last and invokes your `main` method. Using a launcher keeps
 your HTML template clean, as you don't need to specify the `main` function there.

--- a/doc/jp/the-client.md
+++ b/doc/jp/the-client.md
@@ -30,7 +30,7 @@ object SPAMain extends JSApp {
     // create the router
     val router = Router(BaseUrl.until_#, routerConfig)
     // tell React to render the router in the document body
-    React.render(router(), dom.document.getElementById("root"))
+    router().renderIntoDOM(dom.document.getElementById("root"))
   }
 }
 ```

--- a/doc/jp/todo-module-and-data-flow.md
+++ b/doc/jp/todo-module-and-data-flow.md
@@ -60,7 +60,7 @@ Todos.
 val todoCount = props.proxy().getOrElse(0)
 Seq(
   <.span("Todo "),
-  todoCount > 0 ?= <.span(bss.labelOpt(CommonStyle.danger), bss.labelAsBadge, todoCount)
+  <.span(bss.labelOpt(CommonStyle.danger), bss.labelAsBadge, todoCount).when(todoCount > 0)
 )
 ```
 
@@ -164,8 +164,8 @@ case class State(item: TodoItem, cancelled: Boolean = true)
 
 Building the component looks a bit complicated, so let's walk through it.
 ```scala
-val component = ReactComponentB[Props]("TodoForm")
-  .initialState_P(p => State(p.item.getOrElse(TodoItem("", 0, "", TodoNormal, false))))
+val component = ScalaComponent.builder[Props]("TodoForm")
+  .initialStateFromProps(p => State(p.item.getOrElse(TodoItem("", 0, "", TodoNormal, false))))
   .renderBackend[Backend]
   .build
   

--- a/doc/kr/css-in-scala.md
+++ b/doc/kr/css-in-scala.md
@@ -108,7 +108,7 @@ def renderItem(item: TodoItem) = {
     Button(Button.Props(() => P.deleteItem(item), addStyles = Seq(bss.pullRight, bss.buttonXS)), "Delete")
   )
 }
-<.ul(style.listGroup)(P.items map renderItem)
+<.ul(style.listGroup)(P.items toTagMod renderItem)
 ```
 
 부트 스트랩 클래스 이름이 스칼라 메서드 뒤에 "숨겨져"있기 때문에 전체 IDE 코드 완성을 지원하며 클래스 이름을 잘못 입력 할 가능성이 없습니다.

--- a/doc/kr/dashboard.md
+++ b/doc/kr/dashboard.md
@@ -4,9 +4,9 @@
 
 ```scala
 // create the React component for Dashboard
-private val component = ReactComponentB[Props]("Dashboard")
+private val component = ScalaComponent.builder[Props]("Dashboard")
   // create and store the connect proxy in state for later use
-  .initialState_P(props => State(props.proxy.connect(m => m)))
+  .initialStateFromProps(props => State(props.proxy.connect(m => m)))
   .renderPS { (_, props, state) =>
     <.div(
       // header, MessageOfTheDay and chart components
@@ -26,7 +26,7 @@ private val component = ReactComponentB[Props]("Dashboard")
 
 [Motd 구성 요소](https://github.com/ochrons/scalajs-spa-tutorial/tree/master/client/src/main/scala/spatutorial/client/components/Motd.scala)는 간단한 React 구성 요소로서 패널의 서버에서 보낸 *오늘의 메시지*  를 보여줍니다. `Motd`는 프로퍼티(`Pot`와`ModelProxy`로 싸인)에서 메시지를받습니다.
 ```scala
-val Motd = ReactComponentB[ModelProxy[Pot[String]]]("Motd")
+val Motd = ScalaComponent.builder[ModelProxy[Pot[String]]]("Motd")
   .render_P { proxy =>
     Panel(Panel.Props("Message of the day"),
       // render messages depending on the state of the Pot

--- a/doc/kr/integrating-javascript-components.md
+++ b/doc/kr/integrating-javascript-components.md
@@ -21,12 +21,12 @@ object Button {
 
   case class Props(onClick: Callback, style: CommonStyle.Value = CommonStyle.default, addStyles: Seq[StyleA] = Seq())
 
-  val component = ReactComponentB[Props]("Button")
+  val component = ScalaComponent.builder[Props]("Button")
     .renderPC((_, props, children) =>
-      <.button(bss.buttonOpt(props.style), props.addStyles, ^.tpe := "button", ^.onClick --> props.onClick, children)
+      <.button(bss.buttonOpt(props.style), props.addStyles.toTagMod, ^.tpe := "button", ^.onClick --> props.onClick, children)
     ).build
 
-  def apply(props: Props, children: ReactNode*) = component(props, children: _*)
+  def apply(props: Props, children: ReactNode*) = component(props)(children: _*)
   def apply() = component
 }
 ```
@@ -39,7 +39,7 @@ object Button {
 object Panel {
   case class Props(heading: String, style: CommonStyle.Value = CommonStyle.default)
 
-  val component = ReactComponentB[Props]("Panel")
+  val component = ScalaComponent.builder[Props]("Panel")
     .renderPC((_, p, c) =>
       <.div(bss.panelOpt(p.style),
         <.div(bss.panelHeading, p.heading),
@@ -47,7 +47,7 @@ object Panel {
       )
     ).build
 
-  def apply(props: Props, children: ReactNode*) = component(props, children: _*)
+  def apply(props: Props, children: ReactNode*) = component(props)(children: _*)
   def apply() = component
 }
 ```
@@ -60,7 +60,7 @@ object Panel {
 
 ```scala
 object Icon {
-  type Icon = ReactTag
+  type Icon = VdomNode
   def apply(name: String): Icon = <.i(^.className := s"fa fa-$name")
 
   def adjust = apply("adjust")
@@ -89,7 +89,7 @@ Scala.js에서 동일한 작업을 수행하기 위해 다음과 같이 간단�
 
 ```scala
 @js.native
-@JSName("Chart")
+@JSGlobal("Chart")
 class JSChart(ctx: js.Dynamic, config: ChartConfiguration) extends js.Object
 
 @js.native
@@ -100,17 +100,16 @@ trait ChartConfiguration extends js.Object {
 }
 ```
 
-차트를 실제로 인스턴스화하려면 캔버스 요소에 액세스해야하고 React를 사용하면 가상 DOM을 작성하고 장면 뒤의 실제 DOM을 업데이트하므로 조금 문제가 있습니다. 그러므로`render` 함수 호출시 캔버스 요소는 존재하지 않습니다. 이 문제를 해결하려면 실제 DOM이 업데이트 된 후에 호출되는 'componentDidMount` 함수로 차트를 만들어야합니다. 이 함수는`getDOMNode ()`를 통해 실제 DOM 노드에 접근 할 수있게 해주는`scope` 매개 변수와 함께 호출됩니다. 차트는`Chart`의 새로운 인스턴스를 생성하고 적절한 차트 함수를 호출함으로써 만들어집니다.
+차트를 실제로 인스턴스화하려면 캔버스 요소에 액세스해야하고 React를 사용하면 가상 DOM을 작성하고 장면 뒤의 실제 DOM을 업데이트하므로 조금 문제가 있습니다. 그러므로`render` 함수 호출시 캔버스 요소는 존재하지 않습니다. 이 문제를 해결하려면 실제 DOM이 업데이트 된 후에 호출되는 'componentDidMount` 함수로 차트를 만들어야합니다. 이 함수는`getDOMNode`를 통해 실제 DOM 노드에 접근 할 수있게 해주는`scope` 매개 변수와 함께 호출됩니다. 차트는`Chart`의 새로운 인스턴스를 생성하고 적절한 차트 함수를 호출함으로써 만들어집니다.
 
 ```scala
-val Chart = ReactComponentB[ChartProps]("Chart")
+val Chart = ScalaComponent.builder[ChartProps]("Chart")
   .render_P(p =>
-    <.canvas(^.width := s"${p.width}px", ^.height := s"${p.height}px")
+    <.canvas(VdomAttr("width") := p.width, VdomAttr("height") := p.height)
   )
-  .domType[HTMLCanvasElement]
   .componentDidMount(scope => Callback {
     // access context of the canvas
-    val ctx = scope.getDOMNode().getContext("2d")
+    val ctx = scope.getDOMNode.asInstanceOf[HTMLCanvasElement].getContext("2d")
     // create the actual chart using the 3rd party component
     scope.props.style match {
       case LineChart => new JSChart(ctx, ChartConfiguration("line", scope.props.data))
@@ -178,7 +177,7 @@ Bootstrap Modal을 통합하기 전에 먼저 jQuery 컴포넌트를 통합하�
 jQuery는 셀렉터 나 엘리먼트로 "호출"함으로써 작동한다. 이 자습서에서는 항상 직접 DOM 요소를 사용하므로 Facade에는 해당 옵션 만 포함됩니다. 예를 들어 이벤트 리스너를 요소에 연결하려면, 당신은 다음처럼 
 
 ```scala
-jQuery(scope.getDOMNode()).on("hidden.bs.modal", null, null, scope.backend.hidden _)
+jQuery(scope.getDOMNode).on("hidden.bs.modal", null, null, scope.backend.hidden _)
 ```
 
 jQuery에는 플러그인이 jQuery 객체에 새로운 기능을 추가 할 수있는 확장 메커니즘이 있습니다. 예를 들어 부트 스트랩 모달은`모달`함수를 추가합니다. Scala.js에서 이러한 확장을 정의하기 위해이 확장을위한 특성과 그것을위한 암시 적 변환 (실제로 타입 캐스트 만)을 만듭니다.
@@ -201,10 +200,9 @@ jQuery 통합으로 무장 한 이제 Modal 자체를 다룰 수 있습니다. �
 
 ```scala
 class Backend(t: BackendScope[Props, Unit]) {
-  def hide = Callback {
+  def hide =
     // instruct Bootstrap to hide the modal
-    jQuery(t.getDOMNode()).modal("hide")
-  }
+    t.getDOMNode.map(jQuery(_).modal("hide")).void
 ```
 
 그러나 대화 상자 자체에는 대화 상자를 실제로 닫아야하는 컨트롤이 포함되어 있으므로이 기능을 속성을 통해 부모 구성 요소에 노출해야합니다.
@@ -212,7 +210,7 @@ class Backend(t: BackendScope[Props, Unit]) {
 ```scala
 // header and footer are functions, so that they can get access to the 
 // hide() function for their buttons
-case class Props(header: Callback => ReactNode, footer: Callback => ReactNode, 
+case class Props(header: Callback => VdomNode, footer: Callback => VdomNode,
                  closed: Callback, backdrop: Boolean = true,
                  keyboard: Boolean = true)
 ```
@@ -226,7 +224,7 @@ def hidden(e: JQueryEventObject): js.Any = {
 }
 ...
 // register event listener to be notified when the modal is closed
-jQuery(scope.getDOMNode()).on("hidden.bs.modal", null, null, scope.backend.hidden _)
+jQuery(scope.getDOMNode).on("hidden.bs.modal", null, null, scope.backend.hidden _)
 ```
 
 생성 된 대화 상자를 보여주기 위해 우리는 다시`componentDidMount`의 jQuery를 통해`modal ()`을 호출합니다.
@@ -234,6 +232,6 @@ jQuery(scope.getDOMNode()).on("hidden.bs.modal", null, null, scope.backend.hidde
 .componentDidMount(scope => Callback {
   val P = scope.props
   // instruct Bootstrap to show the modal
-  jQuery(scope.getDOMNode()).modal(js.Dynamic.literal("backdrop" -> P.backdrop, "keyboard" -> P.keyboard, "show" -> true))
+  jQuery(scope.getDOMNode).modal(js.Dynamic.literal("backdrop" -> P.backdrop, "keyboard" -> P.keyboard, "show" -> true))
 ```
 

--- a/doc/kr/main-menu.md
+++ b/doc/kr/main-menu.md
@@ -5,14 +5,14 @@
 ```scala
 case class Props(ctl: RouterCtl[Loc], currentLoc: Loc, proxy: ModelProxy[Option[Int]])
 
-case class MenuItem(idx: Int, label: (Props) => ReactNode, icon: Icon, location: Loc)
+case class MenuItem(idx: Int, label: (Props) => VdomNode, icon: Icon, location: Loc)
 
 // build the Todo menu item, showing the number of open todos
-private def buildTodoMenu(props: Props): ReactNode = {
+private def buildTodoMenu(props: Props): VdomElement = {
   val todoCount = props.proxy().getOrElse(0)
   Seq(
     <.span("Todo "),
-    todoCount > 0 ?= <.span(bss.labelOpt(CommonStyle.danger), bss.labelAsBadge, todoCount)
+    <.span(bss.labelOpt(CommonStyle.danger), bss.labelAsBadge, todoCount).when(todoCount > 0)
   )
 }
 
@@ -37,7 +37,7 @@ private class Backend(t: BackendScope[Props, _]) {
     <.ul(bss.navbar)(
       // build a list of menu items
       for (item <- menuItems) yield {
-        <.li(^.key := item.idx, (props.currentLoc == item.location) ?= (^.className := "active"),
+        <.li(^.key := item.idx, (^.className := "active").when(props.currentLoc == item.location),
           props.router.link(item.location)(item.icon, " ", item.label(props))
         )
       }
@@ -45,8 +45,7 @@ private class Backend(t: BackendScope[Props, _]) {
   }
 }
 
-private val component = ReactComponentB[Props]("MainMenu")
-  .stateless
+private val component = ScalaComponent.builder[Props]("MainMenu")
   .renderBackend[Backend]
   .componentDidMount(scope => scope.backend.mounted(scope.props))
   .build

--- a/doc/kr/routing.md
+++ b/doc/kr/routing.md
@@ -26,7 +26,7 @@ val routerConfig = RouterConfigDsl[Loc].buildConfig { dsl =>
 라우터는 기본 HTML 코드 (레이아웃)를 제공하고 애플리케이션을위한`MainMenu` 컴포넌트를 통합합니다. SPA 튜토리얼은 부트 스트랩 CSS를 사용하여보기 좋은 레이아웃을 제공하지만 CSS 클래스 정의를 변경하여 원하는 CSS 프레임 워크를 사용할 수 있습니다.
 
 ```scala
-import japgolly.scalajs.react.vdom.prefix_<^._
+import japgolly.scalajs.react.vdom.html_<^._
 val todoCountWrapper = SPACircuit.connect(_.todos.map(_.items.count(!_.completed)).toOption)
 def layout(c: RouterCtl[Loc], r: Resolution[Loc]) = {
   <.div(
@@ -46,5 +46,5 @@ def layout(c: RouterCtl[Loc], r: Resolution[Loc]) = {
 }
 ```
 
-타입 안전성을 제외하고 IDE가 자동 완성을 제공한다는 점을 제외하고 코드가 HTML과 어떻게 비슷한지 확인하십시오! HTML과 좀 더 닮았다 고 주장한다면`prefix _ <^ ^ '를`all`으로 대체하면 간단한'div`와`className` 태그 이름을 줄 수 있습니다. 그러나 HTML 네임 스페이스에`a`와`id '와 같은 짧은 공통 태그 이름이 많이 포함되어 있기 때문에 이것은 길을 따라 다니는 불쾌한 놀라움으로 이어질 수 있습니다. `<.`과`^ .`의 약간의 노력은 장기적으로 보상합니다.
+타입 안전성을 제외하고 IDE가 자동 완성을 제공한다는 점을 제외하고 코드가 HTML과 어떻게 비슷한지 확인하십시오! HTML과 좀 더 닮았다 고 주장한다면`html _ <^ ^ '를`all`으로 대체하면 간단한'div`와`className` 태그 이름을 줄 수 있습니다. 그러나 HTML 네임 스페이스에`a`와`id '와 같은 짧은 공통 태그 이름이 많이 포함되어 있기 때문에 이것은 길을 따라 다니는 불쾌한 놀라움으로 이어질 수 있습니다. `<.`과`^ .`의 약간의 노력은 장기적으로 보상합니다.
 

--- a/doc/kr/sbt-build-definition.md
+++ b/doc/kr/sbt-build-definition.md
@@ -54,8 +54,8 @@ lazy val client: Project = (project in file("client"))
     // yes, we want to package JS dependencies
     skip in packageJSDependencies := false,
     // use Scala.js provided launcher code to start the client app
-    persistLauncher := true,
-    persistLauncher in Test := false,
+    scalaJSUseMainModuleInitializer := true,
+    scalaJSUseMainModuleInitializer in Test := false,
     // must specify source maps location because we use pure CrossProject
     sourceMapsDirectories += sharedJS.base / "..",
     // use uTest framework for tests
@@ -86,8 +86,8 @@ Eliding은 프로덕트 빌드에서 필요하지 않은 코드 (예 : 디버그
 
 ```scala
     // use Scala.js provided launcher code to start the client app
-    persistLauncher := true,
-    persistLauncher in Test := false,
+    scalaJSUseMainModuleInitializer := true,
+    scalaJSUseMainModuleInitializer in Test := false,
 ```
 이 설정은 특별한`launcher.js` 파일을 생성하도록 Scala.js 플러그인에게 알려주고 마지막에로드되고`main` 메소드를 호출합니다. 런처를 사용하면 HTML 템플릿을 깨끗하게 유지할 수 있습니다. 여기에서`main` 함수를 지정할 필요가 없습니다.
 

--- a/doc/kr/the-client.md
+++ b/doc/kr/the-client.md
@@ -34,7 +34,7 @@ object SPAMain extends JSApp {
     // 라우터 생성
     val router = Router(BaseUrl.until_#, routerConfig)
     // 리액터에게 문서 body 에 라우터를 렌더하라고 말하기
-    React.render(router(), dom.document.getElementById("root"))
+    router().renderIntoDOM(dom.document.getElementById("root"))
   }
 }
 ```

--- a/doc/kr/todo-module-and-data-flow.md
+++ b/doc/kr/todo-module-and-data-flow.md
@@ -47,7 +47,7 @@ class TodoHandler[M](modelRW: ModelRW[M, Pot[Todos]]) extends ActionHandler(mode
 val todoCount = props.proxy().getOrElse(0)
 Seq(
   <.span("Todo "),
-  todoCount > 0 ?= <.span(bss.labelOpt(CommonStyle.danger), bss.labelAsBadge, todoCount)
+  <.span(bss.labelOpt(CommonStyle.danger), bss.labelAsBadge, todoCount).when(todoCount > 0)
 )
 ```
 
@@ -84,7 +84,7 @@ todoWrapper(Todo(_))
 `Dashboard`에서 우리는`ModelProxy`의`connect` 메소드를 사용하여`Motd` 컴포넌트를 모델에 추가로 연결합니다.
 
 ```scala
-.initialState_P(props => State(props.proxy.connect(m => m)))
+.initialStateFromProps(props => State(props.proxy.connect(m => m)))
 ...
 state.motdWrapper(Motd(_))
 ```
@@ -141,8 +141,8 @@ case class State(item: TodoItem, cancelled: Boolean = true)
 
 Building the component looks a bit complicated, so let's walk through it.
 ```scala
-val component = ReactComponentB[Props]("TodoForm")
-  .initialState_P(p => State(p.item.getOrElse(TodoItem("", 0, "", TodoNormal, false))))
+val component = ScalaComponent.builder[Props]("TodoForm")
+  .initialStateFromProps(p => State(p.item.getOrElse(TodoItem("", 0, "", TodoNormal, false))))
   .renderBackend[Backend]
   .build
   

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -23,16 +23,16 @@ object Settings {
   /** Declare global dependency versions here to avoid mismatches in multi part dependencies */
   object versions {
     val scala = "2.11.8"
-    val scalaDom = "0.9.1"
-    val scalajsReact = "0.11.3"
-    val scalaCSS = "0.5.0"
+    val scalaDom = "0.9.2"
+    val scalajsReact = "1.0.1"
+    val scalaCSS = "0.5.3"
     val log4js = "1.4.10"
-    val autowire = "0.2.5"
-    val booPickle = "1.2.5"
-    val diode = "1.1.0"
-    val uTest = "0.4.4"
+    val autowire = "0.2.6"
+    val booPickle = "1.2.6"
+    val diode = "1.1.2"
+    val uTest = "0.4.7"
 
-    val react = "15.3.1"
+    val react = "15.5.4"
     val jQuery = "1.11.1"
     val bootstrap = "3.3.6"
     val chartjs = "2.1.3"
@@ -46,7 +46,7 @@ object Settings {
    */
   val sharedDependencies = Def.setting(Seq(
     "com.lihaoyi" %%% "autowire" % versions.autowire,
-    "me.chrons" %%% "boopickle" % versions.booPickle
+    "io.suzaku" %%% "boopickle" % versions.booPickle
   ))
 
   /** Dependencies only used by the JVM project */
@@ -62,8 +62,8 @@ object Settings {
     "com.github.japgolly.scalajs-react" %%% "core" % versions.scalajsReact,
     "com.github.japgolly.scalajs-react" %%% "extra" % versions.scalajsReact,
     "com.github.japgolly.scalacss" %%% "ext-react" % versions.scalaCSS,
-    "me.chrons" %%% "diode" % versions.diode,
-    "me.chrons" %%% "diode-react" % versions.diode,
+    "io.suzaku" %%% "diode" % versions.diode,
+    "io.suzaku" %%% "diode-react" % versions.diode,
     "org.scala-js" %%% "scalajs-dom" % versions.scalaDom,
     "com.lihaoyi" %%% "utest" % versions.uTest % Test
   ))

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.11
+sbt.version=0.13.15

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,15 +1,15 @@
 // repository for Typesafe plugins
 resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.13")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.17")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.0.6")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.0.0")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.9")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.15")
 
-addSbtPlugin("com.vmunier" % "sbt-web-scalajs" % "1.0.3")
+addSbtPlugin("com.vmunier" % "sbt-web-scalajs" % "1.0.5")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.0")
 


### PR DESCRIPTION
Updates to dependencies:
scalajs-react 1.0.1, Scala.js 0.6.17, sbt-web-scalajs 1.0.5, Play 2.5.15, scalajs-dom 0.9.2, ScalaCSS 0.5.3, Autowire 0.2.6, BooPickle 1.2.6, Diode 1.1.2, uTest 0.4.7, React 15.5.4, SBT 0.13.15

In the Chart.js component I used asInstanceOf in order to access the cavas context because the domType method was removed. There may be a safer way to do that that I couldn't find (I just learned scalajs-react from this tutorial).

The code samples in the documentation were updated although I may have missed a few changes. 