### PR TITLE
upgrades: sbt 1.1.1, sjs 0.6.22, and more

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ lazy val client: Project = (project in file("client"))
     scalacOptions ++= elideOptions.value,
     jsDependencies ++= Settings.jsDependencies.value,
     // RuntimeDOM is needed for tests
-    jsDependencies += RuntimeDOM % "test",
+    jsEnv in Test := new org.scalajs.jsenv.jsdomnodejs.JSDOMNodeJSEnv,
     // yes, we want to package JS dependencies
     skip in packageJSDependencies := false,
     // use Scala.js provided launcher code to start the client app
@@ -60,6 +60,7 @@ lazy val server = (project in file("server"))
     scalaJSProjects := clients,
     pipelineStages in Assets := Seq(scalaJSPipeline),
     pipelineStages := Seq(digest, gzip),
+    libraryDependencies += guice,
     // compress CSS
     LessKeys.compress in Assets := true
   )
@@ -83,4 +84,4 @@ lazy val ReleaseCmd = Command.command("release") {
 // lazy val root = (project in file(".")).aggregate(client, server)
 
 // loads the Play server project at sbt startup
-onLoad in Global := (Command.process("project server", _: State)) compose (onLoad in Global).value
+onLoad in Global := ("project server" :: (_: State)) compose (onLoad in Global).value

--- a/client/src/main/scala/spatutorial/client/SPAMain.scala
+++ b/client/src/main/scala/spatutorial/client/SPAMain.scala
@@ -9,12 +9,12 @@ import spatutorial.client.modules._
 import spatutorial.client.services.SPACircuit
 
 import scala.scalajs.js
-import scala.scalajs.js.annotation.{JSExport, JSExportTopLevel}
+import scala.scalajs.js.annotation.{ JSExport, JSExportTopLevel }
 import CssSettings._
+
 import scalacss.ScalaCssReact._
 
-@JSExportTopLevel("SPAMain")
-object SPAMain extends js.JSApp {
+object SPAMain {
 
   // Define the locations (pages) used in this application
   sealed trait Loc
@@ -53,8 +53,8 @@ object SPAMain extends js.JSApp {
     )
   }
 
-  @JSExport
-  def main(): Unit = {
+  @JSExportTopLevel("SPAMain.main")
+  def main(args: Array[String]): Unit = {
     log.warn("Application starting")
     // send log messages also to the server
     log.enableServerLogging("/logging")

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -37,7 +37,7 @@ object Settings {
     val bootstrap = "3.3.6"
     val chartjs = "2.1.3"
 
-    val scalajsScripts = "1.0.0"
+    val scalajsScripts = "1.1.1"
   }
 
   /**

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.17

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.17
+sbt.version=1.1.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,12 +5,12 @@ addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.22")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.1.2")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.0.0")
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.3")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.15")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.12")
 
 addSbtPlugin("com.vmunier" % "sbt-web-scalajs" % "1.0.6")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.1")
+addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.4")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.0")
+addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.2")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,16 +1,16 @@
 // repository for Typesafe plugins
 resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.18")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.22")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.0.6")
+addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.1.2")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.0.0")
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.15")
 
-addSbtPlugin("com.vmunier" % "sbt-web-scalajs" % "1.0.5")
+addSbtPlugin("com.vmunier" % "sbt-web-scalajs" % "1.0.6")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.0")
+addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.0")

--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -6,3 +6,13 @@ application.cdn=${?APPLICATION_CDN}
 
 spatutorial {
 }
+
+# as seen in https://github.com/playframework/play-scala-streaming-example/pull/38/files:
+# https://www.playframework.com/documentation/latest/SecurityHeaders
+# Allow URLs from the same origin to be loaded by frames and scripts
+play.filters.headers {
+  frameOptions = "SAMEORIGIN"
+  contentSecurityPolicy = "connect-src 'self'"
+}
+
+play.filters.disabled+=play.filters.csrf.CSRFFilter

--- a/server/src/main/scala/controllers/Application.scala
+++ b/server/src/main/scala/controllers/Application.scala
@@ -1,10 +1,10 @@
 package controllers
 
 import java.nio.ByteBuffer
+import javax.inject.Inject
 
 import boopickle.Default._
-import com.google.inject.Inject
-import play.api.{Configuration, Environment}
+import play.api.{ Configuration, Environment }
 import play.api.mvc._
 import services.ApiService
 import spatutorial.shared.Api
@@ -16,7 +16,7 @@ object Router extends autowire.Server[ByteBuffer, Pickler, Pickler] {
   override def write[R: Pickler](r: R) = Pickle.intoBytes(r)
 }
 
-class Application @Inject() (implicit val config: Configuration, env: Environment) extends Controller {
+class Application @Inject() (implicit val config: Configuration, env: Environment) extends InjectedController {
   val apiService = new ApiService()
 
   def index = Action {

--- a/server/src/main/twirl/views/tags/_asset.scala.html
+++ b/server/src/main/twirl/views/tags/_asset.scala.html
@@ -1,1 +1,1 @@
-@(path: String)(implicit config: play.api.Configuration)@{config.getString("application.cdn").getOrElse("") + routes.Assets.versioned(path)}
+@(path: String)(implicit config: play.api.Configuration)@{config.getOptional[String]("application.cdn").getOrElse("") + routes.Assets.versioned(path)}


### PR DESCRIPTION
this tutorial is awesome, thanks!

I'm new to Play and some of the libraries here so some of this is dumb pattern-matching (`InjectedController`) that may not be the right way to do things.

I also disabled CSRF checking because it was 403'ing all requests; it will probably be good to fix that before merging.

Moving the `Settings.scala` into `build.sbt` to be idiomatic SBT 1.x style is a possible addition as well.